### PR TITLE
Implement attribute iterators for call sites and invocations

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -23,9 +23,9 @@ entry
 ## Attributes
 
 ```@docs
-function_attributes
-parameter_attributes
-return_attributes
+function_attributes(::LLVM.Function)
+parameter_attributes(::LLVM.Function, ::Integer)
+return_attributes(::LLVM.Function)
 ```
 
 ## Parameters

--- a/docs/src/lib/instructions.md
+++ b/docs/src/lib/instructions.md
@@ -27,9 +27,9 @@ debuglocation!
 ## Attributes
 
 ```@docs
-function_attributes
-argument_attributes
-return_attributes
+function_attributes(::LLVM.CallBase)
+argument_attributes(::LLVM.CallBase, ::Integer)
+return_attributes(::LLVM.CallBase)
 ```
 
 ## Comparison instructions

--- a/docs/src/lib/instructions.md
+++ b/docs/src/lib/instructions.md
@@ -24,6 +24,13 @@ debuglocation
 debuglocation!
 ```
 
+## Attributes
+
+```@docs
+function_attributes
+argument_attributes
+return_attributes
+```
 
 ## Comparison instructions
 

--- a/docs/src/man/instructions.md
+++ b/docs/src/man/instructions.md
@@ -87,8 +87,9 @@ DocTestSetup = quote
     push!(function_attributes(fun), StringAttribute("nounwind"))
     push!(parameter_attributes(fun, 1), StringAttribute("nocapture"))
     push!(return_attributes(fun), StringAttribute("sret"))
-    caller = LLVM.Function(mod, "CallSomeFunction", LLVM.VoidType(), [LLVM.Int32Type()])
+    caller = LLVM.Function(mod, "CallSomeFunction", function_type(fun))
     top = BasicBlock(caller, "top")
+    builder = LLVM.IRBuilder();
     position!(builder, top)
 end
 ```
@@ -99,7 +100,7 @@ They can be set and retrieved using the iterators returned by the
 to respectively set attributes on the instructions, its arguments and its return value:
 
 ```jldoctest function
-julia> instr = call!(builder, function_type(fun), fun, LLVM.Value[ parameters(fun)... ])
+julia> instr = call!(builder, function_type(fun), fun, LLVM.Value[ parameters(fun)... ]);
 
 julia> push!(function_attributes(instr), StringAttribute("nounwind"))
 

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -402,11 +402,11 @@ Base.delete!(iter::CallSiteAttrSet, attr::LLVM.TypeAttribute) =
 
 function Base.delete!(iter::CallSiteAttrSet, attr::LLVM.StringAttribute)
     k = kind(attr)
-    LLVM.API.LLVMRemoveCallSiteStringAttribute(iter.instr, iter.idx, k, length(k))
+    return LLVM.API.LLVMRemoveCallSiteStringAttribute(iter.instr, iter.idx, k, length(k))
 end
 
 function Base.length(iter::CallSiteAttrSet)
-    LLVM.API.LLVMGetCallSiteAttributeCount(iter.instr, iter.idx)
+    return LLVM.API.LLVMGetCallSiteAttributeCount(iter.instr, iter.idx)
 end
 
 # operand bundles

--- a/src/core/instructions.jl
+++ b/src/core/instructions.jl
@@ -342,6 +342,73 @@ function arguments(inst::CallBase)
     operands(inst)[1:nargs]
 end
 
+# attributes
+
+export function_attributes, argument_attributes, return_attributes
+
+struct CallSiteAttrSet
+    instr::LLVM.CallBase
+    idx::LLVM.API.LLVMAttributeIndex
+end
+
+"""
+    function_attributes(instr::CallBase)
+
+Get the attributes of the given instruction.
+
+This is a mutable iterator, supporting `push!`, `append!` and `delete!`.
+"""
+function_attributes(instr::LLVM.CallBase) =
+    CallSiteAttrSet(instr, reinterpret(LLVM.API.LLVMAttributeIndex, LLVM.API.LLVMAttributeFunctionIndex))
+
+"""
+    argument_attributes(instr::CallBase, idx::Integer)
+
+Get the attributes of the given argument of the given instruction.
+
+This is a mutable iterator, supporting `push!`, `append!` and `delete!`.
+"""
+argument_attributes(instr::LLVM.CallBase, idx::Integer) =
+    CallSiteAttrSet(instr, LLVM.API.LLVMAttributeIndex(idx))
+
+"""
+    return_attributes(instr::CallBase)
+
+Get the attributes of the return value of the given instruction.
+
+This is a mutable iterator, supporting `push!`, `append!` and `delete!`.
+"""
+return_attributes(instr::LLVM.CallBase) = CallSiteAttrSet(instr, LLVM.API.LLVMAttributeReturnIndex)
+
+Base.eltype(::CallSiteAttrSet) = Attribute
+
+function Base.collect(iter::CallSiteAttrSet)
+    elems = Vector{LLVM.API.LLVMAttributeRef}(undef, length(iter))
+    if length(iter) > 0
+      # FIXME: this prevents a nullptr ref in LLVM similar to D26392
+      LLVM.API.LLVMGetCallSiteAttributes(iter.instr, iter.idx, elems)
+    end
+    return LLVM.Attribute[LLVM.Attribute(elem) for elem in elems]
+end
+
+Base.push!(iter::CallSiteAttrSet, attr::LLVM.Attribute) =
+    LLVM.API.LLVMAddCallSiteAttribute(iter.instr, iter.idx, attr)
+
+Base.delete!(iter::CallSiteAttrSet, attr::LLVM.EnumAttribute) =
+    LLVM.API.LLVMRemoveCallSiteEnumAttribute(iter.instr, iter.idx, kind(attr))
+
+Base.delete!(iter::CallSiteAttrSet, attr::LLVM.TypeAttribute) =
+    LLVM.API.LLVMRemoveCallSiteEnumAttribute(iter.instr, iter.idx, kind(attr))
+
+function Base.delete!(iter::CallSiteAttrSet, attr::LLVM.StringAttribute)
+    k = kind(attr)
+    LLVM.API.LLVMRemoveCallSiteStringAttribute(iter.instr, iter.idx, k, length(k))
+end
+
+function Base.length(iter::CallSiteAttrSet)
+    LLVM.API.LLVMGetCallSiteAttributeCount(iter.instr, iter.idx)
+end
+
 # operand bundles
 
 export OperandBundle, operand_bundles, tag, inputs


### PR DESCRIPTION
Implementation is similar to that of function attributes, using a new `CallSiteAttrSet` and the bindings listed here https://llvm.org/doxygen/group__LLVMCCoreValueInstructionCall.html#details.