### PR TITLE
Add `local_unnamed_addr/local_unnamed_addr!` functions

### DIFF
--- a/docs/src/lib/values.md
+++ b/docs/src/lib/values.md
@@ -64,6 +64,8 @@ dllstorage
 dllstorage!
 unnamed_addr
 unnamed_addr!
+local_unnamed_addr
+local_unnamed_addr!
 alignment(::LLVM.GlobalValue)
 alignment!(::LLVM.GlobalValue, ::Integer)
 ```

--- a/docs/src/man/values.md
+++ b/docs/src/man/values.md
@@ -202,6 +202,7 @@ couple of additional APIs:
 - `alignment`/`alignment!`: get or set the alignment of the global value.
 - `dllstorage`/`dllstorage!`: get or set the DLL storage class of the global value.
 - `unnamed_addr`/`unnamed_addr!`: get or set whether the global value has an unnamed address.
+- `local_unnamed_addr`/`local_unnamed_addr!`: get or set whether the global value has a local unnamed address.
 
 The most common type of global value is the global variable, which can be created using the `GlobalVariable` constructor:
 

--- a/src/core/value/constant.jl
+++ b/src/core/value/constant.jl
@@ -796,6 +796,7 @@ export GlobalValue, global_value_type,
        visibility, visibility!,
        dllstorage, dllstorage!,
        unnamed_addr, unnamed_addr!,
+       local_unnamed_addr, local_unnamed_addr!,
        alignment, alignment!
 
 """
@@ -900,14 +901,28 @@ dllstorage!(val::GlobalValue, storage::API.LLVMDLLStorageClass) =
 
 Check if the global value has the unnamed address flag set.
 """
-unnamed_addr(val::GlobalValue) = API.LLVMHasUnnamedAddr(val) |> Bool
+unnamed_addr(val::GlobalValue) = API.LLVMGetUnnamedAddress(val) === API.LLVMGlobalUnnamedAddr
 
 """
     unnamed_addr!(val::LLVM.GlobalValue, flag::Bool)
 
 Set the unnamed address flag of the global value.
 """
-unnamed_addr!(val::GlobalValue, flag::Bool) = API.LLVMSetUnnamedAddr(val, flag)
+unnamed_addr!(val::GlobalValue, flag::Bool) = API.LLVMSetUnnamedAddress(val, flag ? API.LLVMGlobalUnnamedAddr : API.LLVMNoUnnamedAddr)
+
+"""
+    local_unnamed_addr(val::LLVM.GlobalValue)
+
+Check if the global value has the local unnamed address flag set.
+"""
+local_unnamed_addr(val::GlobalValue) = API.LLVMGetUnnamedAddress(val) === API.LLVMLocalUnnamedAddr
+
+"""
+    local_unnamed_addr!(val::LLVM.GlobalValue, flag::Bool)
+
+Set the local unnamed address flag of the global value.
+"""
+local_unnamed_addr!(val::GlobalValue, flag::Bool) = API.LLVMSetUnnamedAddress(val, flag ? API.LLVMLocalUnnamedAddr : API.LLVMNoUnnamedAddr)
 
 """
     alignment(val::LLVM.GlobalValue)

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -785,8 +785,13 @@ end
     @test dllstorage(fn) == LLVM.API.LLVMDLLImportStorageClass
 
     @test !unnamed_addr(fn)
+    @test !local_unnamed_addr(fn)
     unnamed_addr!(fn, true)
     @test unnamed_addr(fn)
+    @test !local_unnamed_addr(fn)
+    local_unnamed_addr!(fn, true)
+    @test !unnamed_addr(fn)
+    @test local_unnamed_addr(fn)
 
     @test alignment(fn) == 0
     alignment!(fn, 4)


### PR DESCRIPTION
Same as `unnamed_addr/unnamed_addr!`.

Also changed implementation of `unnamed_addr` to use `LLVM.GetUnnamedAddress`, because `LLVM.HasUnnamedAddr` is deprecated.